### PR TITLE
RAC-6592: Fix the version of  sonarqube

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ buildscript {
     classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.15"
     classpath(group: 'com.netflix.nebula', name: 'gradle-ospackage-plugin', version: '4.4.0' )
-	classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.2.1"
+	classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1"
 	classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1"
 	//classpath 'com.netflix.nebula:gradle-lint-plugin:latest.release'
 	classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'


### PR DESCRIPTION
**Background**
The Gradle build failed to complete because the sonarqube plugin is out of date.
So, update sonarqube plugin to 2.6.1 in build.gradle

**Reviewers**
@lanchongyizu  @alaricchan